### PR TITLE
Handle nodes with no widgets

### DIFF
--- a/web/js/favorite.js
+++ b/web/js/favorite.js
@@ -60,7 +60,7 @@ app.registerExtension({
             // Collect menu items first
             const menuItems = [];
 
-            node.widgets.forEach((widget) => {
+            node.widgets?.forEach((widget) => {
                 if (widget.type === "combo") {
                     const value = widget.value;
                     if (value.has_submenu) {


### PR DESCRIPTION
Without this when right clicking a node I get `Uncaught TypeError: can't access property "forEach", node.widgets is undefined` in browser console and node context menu does not open at all.