### PR TITLE
Fix phantom tooltip appearing after mouse leaves tag

### DIFF
--- a/web/js/textHighlight.js
+++ b/web/js/textHighlight.js
@@ -276,11 +276,23 @@ async function syncText(inputEl, overlayEl, tries = 1) {
     overlayEl.innerHTML = result;
 }
 
+// Track the current tooltip request to allow cancellation
+let currentTooltipRequest = null;
+
 async function showTagTooltip(element, tag) {
-    let tooltip = document.getElementById("tag-tooltip");
+    // Create a cancellation token for this request
+    const requestId = Symbol('tooltip-request');
+    currentTooltipRequest = requestId;
+
     const description =
         (await booruApi.getTagDescription(tag)) ?? "No description available.";
 
+    // Check if this request was cancelled while we were fetching
+    if (currentTooltipRequest !== requestId) {
+        return;
+    }
+
+    let tooltip = document.getElementById("tag-tooltip");
     if (!tooltip) {
         tooltip = document.createElement("div");
         tooltip.id = "tag-tooltip";
@@ -329,6 +341,9 @@ async function showTagTooltip(element, tag) {
 }
 
 function hideTagTooltip() {
+    // Cancel any pending tooltip request
+    currentTooltipRequest = null;
+
     const tooltips = document.querySelectorAll("#tag-tooltip");
     tooltips.forEach((tooltip) => {
         tooltip.remove();


### PR DESCRIPTION
When hovering over a tag and quickly moving away, the tooltip would sometimes appear after the cursor had already left, and would not disappear until triggering another tooltip. This only occurred with tags that hadn't been previously displayed (not in cache).

### Root Cause
The `showTagTooltip` function is async and fetches tag descriptions from the Danbooru API. When hovering over an uncached tag:
1. Timeout fires and calls `showTagTooltip`
2. Function starts fetching data from API (100-500ms)
3. User moves mouse away during the fetch
4. API fetch completes and tooltip displays despite user having moved away

For cached tags, the response is instant, so the tooltip appears before the user can move away.

### Solution
Implemented a cancellation token pattern using a Symbol-based request ID:
- Each `showTagTooltip` call generates a unique `requestId` and stores it in `currentTooltipRequest`
- After the async API call completes, the function checks if its `requestId` is still current
- If the request was superseded or cancelled, the function returns early without showing the tooltip
- `hideTagTooltip` sets `currentTooltipRequest = null` to cancel any pending requests

This ensures tooltips only display if the request is still valid when the async operation completes.