### PR TITLE
Highlight wildcard syntax (optional)

### DIFF
--- a/web/js/highlighting/highlighter.js
+++ b/web/js/highlighting/highlighter.js
@@ -10,6 +10,7 @@ export class SyntaxHighlighter {
     resetState() {
         this.nestingLevel = 0;
         this.spanStack = [];
+        this.wildcardStack = [];
         this.uniqueIdCounter = 0;
         this.uniqueIdMap = new Map();
     }
@@ -63,6 +64,12 @@ export class SyntaxHighlighter {
             case TokenType.PAREN_CLOSE:
                 return this.processCloseTag(token, tokens, index);
 
+            case TokenType.WILDCARD_OPEN:
+                return this.processWildcardOpen(token);
+
+            case TokenType.WILDCARD_CLOSE:
+                return this.processWildcardClose(token);
+
             default:
                 return escapeHtml(token.value);
         }
@@ -82,6 +89,23 @@ export class SyntaxHighlighter {
         return `<span id="${uniqueId}" style="background-color: ${color};">${escapeHtml(
             token.value
         )}</span>`;
+    }
+
+    processWildcardOpen(token) {
+        if (!this.resources.wildcardHighlight) return escapeHtml(token.value);
+        const { wildcardColor } = this.resources;
+        const uniqueId = this.generateUniqueId("-wildcard");
+        this.wildcardStack.push({ id: uniqueId });
+        this.uniqueIdMap.set(uniqueId, wildcardColor);
+        return `<span id="${uniqueId}" style="background-color: PLACEHOLDER_${uniqueId};">${escapeHtml(token.value)}`;
+    }
+
+    processWildcardClose(token) {
+        if (!this.resources.wildcardHighlight || this.wildcardStack.length === 0) {
+            return escapeHtml(token.value);
+        }
+        this.wildcardStack.pop();
+        return `${escapeHtml(token.value)}</span>`;
     }
 
     processOpenTag(token) {
@@ -271,6 +295,11 @@ export class SyntaxHighlighter {
         while (this.spanStack.length > 0) {
             const unclosedSpan = this.spanStack.pop();
             this.uniqueIdMap.set(unclosedSpan.id, this.resources.errorColor);
+            result += "</span>";
+        }
+        while (this.wildcardStack.length > 0) {
+            const unclosedWildcard = this.wildcardStack.pop();
+            this.uniqueIdMap.set(unclosedWildcard.id, this.resources.errorColor);
             result += "</span>";
         }
         return result;

--- a/web/js/highlighting/tokenizer.js
+++ b/web/js/highlighting/tokenizer.js
@@ -7,6 +7,8 @@ export const TokenType = {
     EMBEDDING: "embedding",
     ESCAPE: "escape",
     INVALID_ESCAPE: "invalid_escape",
+    WILDCARD_OPEN: "wildcard_open",
+    WILDCARD_CLOSE: "wildcard_close",
 };
 
 export class SyntaxTokenizer {
@@ -19,6 +21,8 @@ export class SyntaxTokenizer {
             { type: TokenType.LORA_CLOSE, regex: />/g },
             { type: TokenType.PAREN_OPEN, regex: /\(/g },
             { type: TokenType.PAREN_CLOSE, regex: /\)/g },
+            { type: TokenType.WILDCARD_OPEN, regex: /\{/g },
+            { type: TokenType.WILDCARD_CLOSE, regex: /\}/g },
         ];
     }
 

--- a/web/js/settings.js
+++ b/web/js/settings.js
@@ -24,6 +24,21 @@ const settingsDefinitions = [
         onChange: () => SettingsHelper.PresetOnChange.reloadSettings(),
     },
     {
+        name: "Wildcard Highlighting",
+        category: ["Syntax Highlighting", "Textbox", "WildcardHighlighting"],
+        defaultValue: true,
+        tooltip: "Highlight wildcard sets enclosed in {} (e.g. Impact Pack wildcards).",
+        type: SettingsHelper.ST.BOOLEAN,
+        onChange: () => SettingsHelper.PresetOnChange.reloadSettings(),
+    },
+    {
+        name: "Wildcard Color",
+        category: ["Syntax Highlighting", "Textbox", "WildcardColor"],
+        defaultValue: "#c47900",
+        type: SettingsHelper.ST.COLORPICKER,
+        onChange: () => SettingsHelper.PresetOnChange.reloadSettings(),
+    },
+    {
         name: "Tag Tooltips",
         category: ["Syntax Highlighting", "Textbox", "TextboxTooltips"],
         defaultValue: false,

--- a/web/js/textHighlight.js
+++ b/web/js/textHighlight.js
@@ -12,7 +12,9 @@ const globalResources = {
     validLoras: null,
     validEmbeddings: null,
     colors: null,
-    highlightType: "nesting", // Default to nesting instead of false
+    wildcardColor: null,
+    wildcardHighlight: true,
+    highlightType: "nesting",
     errorColor: "var(--error-text)",
 };
 
@@ -177,13 +179,15 @@ async function setTextHighlightType() {
 }
 
 async function updateTextColors() {
-    const customTextboxColors = await settingsHelper.getSetting(
-        "Textbox Colors"
-    );
+    const customTextboxColors = await settingsHelper.getSetting("Textbox Colors");
+    const wildcardColor = await settingsHelper.getSetting("Wildcard Color");
+    const wildcardHighlight = await settingsHelper.getSetting("Wildcard Highlighting");
     await setTextHighlightType();
     globalResources.colors = customTextboxColors
         .split("\n")
         .map((color) => (color.charAt(0) === "#" ? hexToRgb(color) : color));
+    globalResources.wildcardColor = wildcardColor.charAt(0) === "#" ? hexToRgb(wildcardColor) : wildcardColor;
+    globalResources.wildcardHighlight = wildcardHighlight;
 }
 
 function setTextColors(inputEl, overlayEl) {
@@ -199,11 +203,13 @@ async function syncText(inputEl, overlayEl, tries = 1) {
     const errorColor = globalResources.errorColor;
     const shouldHighlightGradient = globalResources.highlightType;
     const loraColor = colors ? colors[0] : undefined;
+    const wildcardColor = globalResources.wildcardColor;
 
     if (
         !colors ||
         !errorColor ||
         !loraColor ||
+        !wildcardColor ||
         shouldHighlightGradient === undefined
     ) {
         if (tries < 5) {


### PR DESCRIPTION
Highlights `{option1|option2|...}` wildcard syntax as used by extensions like [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack).

An unclosed `{` turns the error color, and an orphan `}` renders as plain text.

Resolves #5.

